### PR TITLE
Use pop() to delete http_proxy environ

### DIFF
--- a/fossdriver-test.py
+++ b/fossdriver-test.py
@@ -19,8 +19,8 @@ from fossdriver.config import FossConfig
 from fossdriver.server import FossServer
 from fossdriver.tasks import (CreateFolder, Upload, Scanners, Copyright, Reuse, BulkTextMatch, SPDXTV)
 
-del os.environ['http_proxy']
-del os.environ['https_proxy']
+os.environ.pop('http_proxy', None)
+os.environ.pop('https_proxy', None)
 
 config = FossConfig()
 configPath = os.path.join(os.path.expanduser('~'),".fossdriverrc")


### PR DESCRIPTION
When http_proxy is not set, this program raises KeyError.

  Traceback (most recent call last):
    File "./fossdriver-test.py", line 22, in \<module\>
      del os.environ['http_proxy']
    File "/usr/lib/python3.6/os.py", line 685, in \_\_delitem\_\_
      raise KeyError(key) from None
  KeyError: 'http_proxy'

We can fix the problem by using pop() with a second parameter.